### PR TITLE
Microbes fixes

### DIFF
--- a/THP/TrackHubFact.pm
+++ b/THP/TrackHubFact.pm
@@ -9,6 +9,7 @@ use File::Basename;
 use base ('Bio::EnsEMBL::Hive::Process');
 
 
+
 sub param_defaults {
 
     return {
@@ -74,9 +75,9 @@ sub run {
 	    my $url_name = $href->{url_name};
 	    for my $defined ($species_production_name,$assembly_accession,$assembly_name,$assembly_default,$url_name) {
 		warn "Could not get all expected fields (name,assembly_accession,assembly_name,assembly_default) for Ensembl genomes from $self->{url_genomes}\n" unless defined($defined) and length $defined;
-            	$self->{plant_db}->add_ensgenome($species_production_name, $assembly_accession, $assembly_name, $assembly_default, $url_name, $self->{piperun});
-		next HREF;
+	   	next HREF;
 	     }
+	    $self->{plant_db}->add_ensgenome($species_production_name, $assembly_accession, $assembly_name, $assembly_default, $url_name, $self->{piperun});
 	}
     } 
 }

--- a/THP/TrackHubFact.pm
+++ b/THP/TrackHubFact.pm
@@ -9,7 +9,6 @@ use File::Basename;
 use base ('Bio::EnsEMBL::Hive::Process');
 
 
-
 sub param_defaults {
 
     return {
@@ -75,9 +74,9 @@ sub run {
 	    my $url_name = $href->{url_name};
 	    for my $defined ($species_production_name,$assembly_accession,$assembly_name,$assembly_default,$url_name) {
 		warn "Could not get all expected fields (name,assembly_accession,assembly_name,assembly_default) for Ensembl genomes from $self->{url_genomes}\n" unless defined($defined) and length $defined;
-	   	next HREF;
+            	$self->{plant_db}->add_ensgenome($species_production_name, $assembly_accession, $assembly_name, $assembly_default, $url_name, $self->{piperun});
+		next HREF;
 	     }
-	    $self->{plant_db}->add_ensgenome($species_production_name, $assembly_accession, $assembly_name, $assembly_default, $url_name, $self->{piperun});
 	}
     } 
 }

--- a/THP/TrackHubFact.pm
+++ b/THP/TrackHubFact.pm
@@ -74,8 +74,10 @@ sub run {
 	    my $assembly_default = $href->{assembly_default};
 	    my $url_name = $href->{url_name};
 	    for my $defined ($species_production_name,$assembly_accession,$assembly_name,$assembly_default,$url_name) {
-		warn "Could not get all expected fields (name,assembly_accession,assembly_name,assembly_default) for Ensembl genomes from $self->{url_genomes}\n" unless defined($defined) and length $defined;
-	   	next HREF;
+		if (!defined($defined) || !length $defined) {
+			warn "Could not get all expected fields (name,assembly_accession,assembly_name,assembly_default) for Ensembl genomes from $self->{url_genomes}\n" ;
+			next HREF;
+	   	}
 	     }
 	    $self->{plant_db}->add_ensgenome($species_production_name, $assembly_accession, $assembly_name, $assembly_default, $url_name, $self->{piperun});
 	}


### PR DESCRIPTION
'next HREF' was preventing  add_ensgenome  to be called ( it was called wether the arguments verification -$defined- was successful or not and therefore  NAME_CHECK was never being populated).
The reason why this bug has gone unnoticed was probably because Plants has been using the same DB across releases and the table is pre-populated, but its values have not been updated in a while. Since Protists needed a new DB and no previous values existed this needed to be fixed.