### PR TITLE
limit analysis_capacity of hub_write to 100 

### DIFF
--- a/THP/GetMetaWriteHub_conf.pm
+++ b/THP/GetMetaWriteHub_conf.pm
@@ -59,6 +59,7 @@ sub pipeline_analyses {
 	{
 	    -logic_name   => 'hub_write',
 	    -module       => 'THP::TrackHubDir',
+	    -analysis_capacity  =>  100,
 	},
 	{
 	    -logic_name   => 'hub_register',


### PR DESCRIPTION
This edit is to limit the #connections to the ehive db server while running THP::GetMetaWriteHub_conf @manuelcarbajo @gnaamati @nds 